### PR TITLE
Fixes up dockerfiles so the containers can build

### DIFF
--- a/wifi2msghub/Dockerfile.arm
+++ b/wifi2msghub/Dockerfile.arm
@@ -8,6 +8,7 @@ RUN apk update && apk add build-base autoconf automake libtool git make curl-dev
 RUN git clone https://github.com/json-c/json-c.git
 # RUN apt install -y autoconf automake libtool
 # RUN apt install -y libcurl3-dev
+RUN cd json-c; git checkout 96ab2f6596
 RUN cd json-c; ./autogen.sh
 RUN cd json-c; ./configure
 RUN cd json-c; make
@@ -15,7 +16,7 @@ RUN cd json-c; make install
 
 # Steps to build test1
 COPY test1.c /
-RUN gcc -g test1.c -o test1 -lcurl -ljson-c
+RUN gcc -Ijson-c -g test1.c -o test1 -lcurl -ljson-c
 
 
 # STAGE 1

--- a/wifisignalscan/Dockerfile.arm
+++ b/wifisignalscan/Dockerfile.arm
@@ -9,5 +9,7 @@ RUN apt update && apt install -y socat && apt install -y vim jq
 COPY service.sh /
 COPY start.sh /
 WORKDIR /
+RUN chmod +x start.sh
+RUN chmod +x service.sh
 CMD ./start.sh
 


### PR DESCRIPTION
This commit fixes up the dockerfiles so this example can build again. Specifically:

For `wifi2msghub`:
1. `json-c` has deprecated the `./autogen.sh` pattern to switch to CMake to build. I have checked out the repo at the commit before that as a short term fix, but we should probably overhaul the Dockerfile when we have more time.

2. I used option `gcc -I` to link the `json-c` files as header files, because for some reason `gcc` wasn't detecting `json_types.h` in the `json-c` directory.

For `wifisignalscan`:
1. I was running into a permissions error while running `./start.sh`, which was revealed by `docker ps -a` and `docker logs <container_id>`. Thanks @edeediong for the debugging suggestions!

Tested by running these Dockerfiles on a Raspberry Pi 3 and amd64 architecture.

Signed-off-by: Clement Ng <clementdng@gmail.com>