### PR TITLE
Expose iwlist stats to outside the container

### DIFF
--- a/wifisignalscan/Dockerfile.arm
+++ b/wifisignalscan/Dockerfile.arm
@@ -5,6 +5,8 @@ RUN apt update && apt install -y vim jq
 FROM ubuntu:18.04
  
 RUN apt update && apt install -y socat && apt install -y vim jq
+
+EXPOSE 34567
        
 COPY service.sh /
 COPY start.sh /


### PR DESCRIPTION
The `wifi2msghub` service needs to `curl` the `wifisignalscan` for wireless information, but the port was never exposed so the data would not come through.

Signed-off-by: Clement Ng <clementdng@gmail.com>